### PR TITLE
Add fuzz test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/erigontech/secp256k1
 
 go 1.16
+
+require github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=

--- a/secp256_fuzz_test.go
+++ b/secp256_fuzz_test.go
@@ -1,0 +1,36 @@
+package secp256k1
+
+import (
+	"fmt"
+	"testing"
+
+	dcred_secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+func TestFuzzer(t *testing.T) {
+	a, b := "00000000N0000000/R0000000000000000", "0U0000S0000000mkhP000000000000000U"
+	fuzz([]byte(a), []byte(b))
+}
+
+func Fuzz(f *testing.F) {
+	f.Fuzz(func(t *testing.T, a, b []byte) {
+		fuzz(a, b)
+	})
+}
+
+func fuzz(dataP1, dataP2 []byte) {
+	var (
+		curveA = S256()
+		curveB = dcred_secp256k1.S256()
+	)
+	// first point
+	x1, y1 := curveB.ScalarBaseMult(dataP1)
+	// second points
+	x2, y2 := curveB.ScalarBaseMult(dataP2)
+	resAX, resAY := curveA.Add(x1, y1, x2, y2)
+	resBX, resBY := curveB.Add(x1, y1, x2, y2)
+	if resAX.Cmp(resBX) != 0 || resAY.Cmp(resBY) != 0 {
+		fmt.Printf("%s %s %s %s\n", x1, y1, x2, y2)
+		panic(fmt.Sprintf("Addition failed: geth: %s %s btcd: %s %s", resAX, resAY, resBX, resBY))
+	}
+}


### PR DESCRIPTION
Move it from [erigon](https://github.com/erigontech/erigon/blob/main/tests/fuzzers/secp256k1/secp_test.go). See also https://github.com/erigontech/erigon/pull/17688