### PR TITLE
[SharovBot] fix: reject coordinates >= P in IsOnCurve and secp256k1_ext_scalar_mul

### DIFF
--- a/curve.go
+++ b/curve.go
@@ -92,6 +92,11 @@ func (BitCurve *BitCurve) Params() *elliptic.CurveParams {
 
 // IsOnCurve returns true if the given (x,y) lies on the BitCurve.
 func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
+	// Reject coordinates >= P to prevent reduced-modulo bypass.
+	if x.Sign() < 0 || y.Sign() < 0 || x.Cmp(BitCurve.P) >= 0 || y.Cmp(BitCurve.P) >= 0 {
+		return false
+	}
+
 	// y² = x³ + b
 	y2 := new(big.Int).Mul(y, y) //y²
 	y2.Mod(y2, BitCurve.P)       //y²%P

--- a/ext.h
+++ b/ext.h
@@ -109,8 +109,10 @@ int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point,
 	ARG_CHECK(scalar != NULL);
 	(void)ctx;
 
-	secp256k1_fe_set_b32_mod(&feX, point);
-	secp256k1_fe_set_b32_mod(&feY, point+32);
+	if (!secp256k1_fe_set_b32_limit(&feX, point) ||
+		!secp256k1_fe_set_b32_limit(&feY, point+32)) {
+		return 0;
+	}
 	secp256k1_ge_set_xy(&ge, &feX, &feY);
 	secp256k1_scalar_set_b32(&s, scalar, &overflow);
 	if (overflow || secp256k1_scalar_is_zero(&s)) {

--- a/secp256_test.go
+++ b/secp256_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"io"
+	"math/big"
 	"testing"
 )
 
@@ -234,5 +235,35 @@ func BenchmarkRecover(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		RecoverPubkey(msg, sig)
+	}
+}
+
+func TestIsOnCurveRejectsCoordinatesGeP(t *testing.T) {
+	curve := S256()
+	// Use the generator point
+	gx := curve.Params().Gx
+	gy := curve.Params().Gy
+
+	// Valid point should be on curve
+	if !curve.IsOnCurve(gx, gy) {
+		t.Fatal("generator should be on curve")
+	}
+
+	// x + P should NOT be on curve (coordinates >= P must be rejected)
+	xPlusP := new(big.Int).Add(gx, curve.Params().P)
+	if curve.IsOnCurve(xPlusP, gy) {
+		t.Fatal("IsOnCurve should reject x >= P")
+	}
+
+	// y + P should NOT be on curve
+	yPlusP := new(big.Int).Add(gy, curve.Params().P)
+	if curve.IsOnCurve(gx, yPlusP) {
+		t.Fatal("IsOnCurve should reject y >= P")
+	}
+
+	// Negative coordinates should be rejected
+	negX := new(big.Int).Neg(gx)
+	if curve.IsOnCurve(negX, gy) {
+		t.Fatal("IsOnCurve should reject negative x")
 	}
 }


### PR DESCRIPTION
**[SharovBot]**

## Summary

Defense-in-depth fix for CVE-2026-26313 / CVE-2026-26314 from the geth v1.16.9 security release.

### Changes

1. **`IsOnCurve`** (`curve.go`): Reject coordinates `x >= P`, `y >= P`, or negative values. Previously these were silently reduced mod P, which means `IsOnCurve(x+P, y)` would return `true` for any valid point `(x, y)`.

2. **`secp256k1_ext_scalar_mul`** (`ext.h`): Use `secp256k1_fe_set_b32_limit` instead of `secp256k1_fe_set_b32_mod` and check return values. This rejects field element overflows at the C level before ECDH.

3. **Test**: Added `TestIsOnCurveRejectsCoordinatesGeP` verifying coordinates >= P and negative coordinates are rejected.

### Context

- Mirrors go-ethereum fix: ethereum/go-ethereum@895a8597
- Geth advisories: GHSA-689v-6xwf-5jf3, GHSA-2gjw-fg97-vg3r
- Erigon's ECIES `GenerateShared` already validates `IsOnCurve` before ECDH (the critical CVE-2026-26315 fix is already applied), so this is defense-in-depth