### PR TITLE
fix: validate coordinate bounds in IsOnCurve and scalar mul

### DIFF
--- a/curve.go
+++ b/curve.go
@@ -92,6 +92,9 @@ func (BitCurve *BitCurve) Params() *elliptic.CurveParams {
 
 // IsOnCurve returns true if the given (x,y) lies on the BitCurve.
 func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
+	if x.Cmp(BitCurve.P) >= 0 || y.Cmp(BitCurve.P) >= 0 {
+		return false
+	}
 	// y² = x³ + b
 	y2 := new(big.Int).Mul(y, y) //y²
 	y2.Mod(y2, BitCurve.P)       //y²%P

--- a/ext.h
+++ b/ext.h
@@ -109,8 +109,10 @@ int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point,
 	ARG_CHECK(scalar != NULL);
 	(void)ctx;
 
-	secp256k1_fe_set_b32_mod(&feX, point);
-	secp256k1_fe_set_b32_mod(&feY, point+32);
+	if (!secp256k1_fe_set_b32_limit(&feX, point) ||
+		!secp256k1_fe_set_b32_limit(&feY, point+32)) {
+		return 0;
+	}
 	secp256k1_ge_set_xy(&ge, &feX, &feY);
 	secp256k1_scalar_set_b32(&s, scalar, &overflow);
 	if (overflow || secp256k1_scalar_is_zero(&s)) {


### PR DESCRIPTION
Before executing curve operations, this modification adds explicit validation to make sure that the curve point coordinates fall inside the secp256k1 finite field. In the past, `IsOnCurve` did not check if the given `(x, y)` coordinates were valid field elements (i.e. `< P`); instead, it just validated the curve equation. Values larger than or equal to the field prime may fulfill the equation after reduction even though they do not represent valid curve points since the equation is evaluated modulo P.

`Secp256k1_fe_set_b32_mod`, which implicitly decreases coordinates modulo `P` and enables out-of-range inputs to be discreetly normalized into valid field elements, was also utilized by `secp256k1_text_scalar_mul`. In this PR, `secp256k1_fe_set_b32_limit` is used to fail on invalid coordinates rather than decreasing them modulo P, replacing `IsOnCurve`, which is updated to reject inputs when `x >= P` or `y >= P`.


Ref: https://github.com/ethereum/go-ethereum/commit/9b78f45e337f01e66b505c35b74415751b2a0a28