### PR TITLE
ci: add build/lint/zizmor workflow and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: build, vet, fmt, test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+      - name: gofmt
+        run: |
+          unformatted="$(gofmt -l . | grep -v '^libsecp256k1/' || true)"
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-ed:"
+            echo "$unformatted"
+            exit 1
+          fi
+      - name: go vet
+        run: go vet ./...
+      - name: go build
+        run: go build ./...
+      - name: go test
+        run: go test -count=1 ./...
+
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.6.0
+
+  zizmor:
+    name: zizmor (workflow security)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Run zizmor
+        run: uvx zizmor@1.28.0 --offline --persona regular .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Run zizmor
-        run: uvx zizmor@1.28.0 --offline --persona regular .
+        run: uvx zizmor@1.28.0 --offline --persona regular .github/workflows/

--- a/curve.go
+++ b/curve.go
@@ -108,7 +108,7 @@ func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
 	return x3.Cmp(y2) == 0
 }
 
-//TODO: double check if the function is okay
+// TODO: double check if the function is okay
 // affineFromJacobian reverses the Jacobian transform. See the comment at the
 // top of the file.
 func (BitCurve *BitCurve) affineFromJacobian(x, y, z *big.Int) (xOut, yOut *big.Int) {

--- a/secp256_test.go
+++ b/secp256_test.go
@@ -222,7 +222,7 @@ func BenchmarkSign(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		Sign(msg, seckey)
+		_, _ = Sign(msg, seckey)
 	}
 }
 
@@ -233,6 +233,6 @@ func BenchmarkRecover(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		RecoverPubkey(msg, sig)
+		_, _ = RecoverPubkey(msg, sig)
 	}
 }


### PR DESCRIPTION
Adds basic CI and dependency automation to the repo (kept separate from the libsecp256k1 0.7.1 bump in #9).

## Workflow (`.github/workflows/ci.yml`, ubuntu-latest)
- **go**: gofmt check, `go vet`, `go build`, `go test` (native cgo).
- **golangci-lint**: default linters (v2).
- **zizmor**: GitHub Actions security scan, run offline (no token needed).

Hardening: workflow-level `permissions: contents: read`, all actions pinned to commit SHAs, `persist-credentials: false` on checkout. The workflow passes its own zizmor scan (no findings).

## Lint fixes (to make the new checks green on existing code)
- `curve.go`: gofmt a stray `//TODO` comment (unformatted since #8).
- `secp256_test.go`: check the ignored return values in the Sign/Recover benchmarks (errcheck).

## Dependabot (`.github/dependabot.yml`)
- Weekly updates for `gomod` and `github-actions`. (Free on GitHub; no Advanced Security required.)

Verified locally: gofmt clean, `go vet` clean, `golangci-lint` 0 issues, tests pass, zizmor no findings.